### PR TITLE
renaming from contextRoutung to context Routing

### DIFF
--- a/src/routing.js
+++ b/src/routing.js
@@ -126,7 +126,7 @@ class Routing {
         host = token[1] + value + host;
       }
     });
-    url = this.contextRoutung.base_url + url;
+    url = this.contextRouting.base_url + url;
     if (
       route.requirements[schemaVar] &&
       this.getScheme() !== route.requirements[schemaVar]


### PR DESCRIPTION
Correction when renaming contextRoutung by contextRouting.